### PR TITLE
Remove check for accessToken on Users feed

### DIFF
--- a/instafeed.js
+++ b/instafeed.js
@@ -222,9 +222,6 @@
           if (typeof this.options.userId !== 'number') {
             throw new Error("No user specified. Use the 'userId' option.");
           }
-          if (typeof this.options.accessToken !== 'string') {
-            throw new Error("No access token. Use the 'accessToken' option.");
-          }
           endpoint = "users/" + this.options.userId + "/media/recent";
           break;
         default:

--- a/src/instafeed.coffee
+++ b/src/instafeed.coffee
@@ -274,10 +274,6 @@ class Instafeed
         if typeof @options.userId isnt 'number'
           throw new Error "No user specified. Use the 'userId' option."
 
-        # make sure there is an access token
-        if typeof @options.accessToken isnt 'string'
-          throw new Error "No access token. Use the 'accessToken' option."
-
         endpoint = "users/#{@options.userId}/media/recent"
       # throw an error if any other option is given
       else throw new Error "Invalid option for get: '#{@options.get}'."

--- a/test/instafeedTest.coffee
+++ b/test/instafeedTest.coffee
@@ -97,13 +97,6 @@ describe 'Instafeed instace', ->
       accessToken: 'mytoken'
     (-> feed._buildUrl()).should.throw "No user specified. Use the 'userId' option."
 
-  it 'should refuse to build a url if get=user and there is no accessToken', ->
-    feed = new Instafeed
-      clientId: 'test'
-      get: 'user'
-      userId: 1
-    (-> feed._buildUrl()).should.throw "No access token. Use the 'accessToken' option."
-
   it 'should run a before & after callback functions', ->
     timesRan = 0
     callback = ->


### PR DESCRIPTION
accessToken OR clientId can be used for the specified endpoint:
```
endpoint = "users/" + this.options.userId + "/media/recent";
```

There are 2 endpoints available. Refer to API docs.
http://instagram.com/developer/endpoints/users/#get_users_media_recent

Fixes #102 

