### PR TITLE
Close #659: Re-instate the before hook

### DIFF
--- a/src/instafeed.js
+++ b/src/instafeed.js
@@ -22,6 +22,7 @@
       accessTokenTimeout: 5000,
       after: null,
       apiTimeout: 5000,
+      before: null,
       debug: false,
       error: null,
       filter: null,
@@ -60,6 +61,7 @@
     assert(typeof opts.templateBoundaries === 'object' && opts.templateBoundaries.length === 2 && typeof opts.templateBoundaries[0] === 'string' && typeof opts.templateBoundaries[1] === 'string', 'templateBoundaries must be an array of 2 strings, got ' + opts.templateBoundaries + ' ('+ typeof opts.templateBoundaries +')');
     assert(!opts.template || typeof opts.template === 'string', 'template must null or string, got ' + opts.template + ' ('+ typeof opts.template +')');
     assert(!opts.error || typeof opts.error === 'function', 'error must be null or function, got ' + opts.error + ' ('+ typeof opts.error +')');
+    assert(!opts.before || typeof opts.before === 'function', 'before must be null or function, got ' + opts.before + ' ('+ typeof opts.before +')');
     assert(!opts.after || typeof opts.after === 'function', 'after must be null or function, got ' + opts.after + ' ('+ typeof opts.after +')');
     assert(!opts.success || typeof opts.success === 'function', 'success must be null or function, got ' + opts.success + ' ('+ typeof opts.success +')');
     assert(!opts.filter || typeof opts.filter === 'function', 'filter must be null or function, got ' + opts.filter + ' ('+ typeof opts.filter +')');
@@ -90,7 +92,7 @@
     }
 
     // set as running
-    this._state.running = true;
+    this._start();
 
     // get dom node
     this._debug('run', 'getting dom node');
@@ -348,6 +350,11 @@
       console.error(err);
     }
     this._state.running = false;
+  };
+
+  Instafeed.prototype._start = function start() {
+    this._state.running = true;
+    this._runHook('before');
   };
 
   Instafeed.prototype._finish = function finish() {


### PR DESCRIPTION
Just adds the option for a before function. This is called in the equivalent place to v1: After checking the access token, but before making any network calls.